### PR TITLE
Refactoring lively.modules to create dedicated Module class

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,10 +222,7 @@ import { obj, arr } from "lively.lang";
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 import {
   getSystem, removeSystem, prepareSystem,
-  moduleEnv as _moduleEnv,
-  moduleRecordFor as _moduleRecordFor,
-  sourceOf as _sourceOf,
-  searchModule as _searchModule,
+  module as _module,
   printSystemConfig as _printSystemConfig
 } from "./src/system.js";
 
@@ -240,10 +237,7 @@ function changeSystem(newSystem, makeGlobal) {
   return newSystem;
 }
 function loadedModules() { return Object.keys(lively.modules.requireMap()); }
-function sourceOf(id) { return _sourceOf(defaultSystem, id); }
-function searchModule(id, str) { return _searchModule(defaultSystem, id, str); }
-function moduleEnv(id) { return _moduleEnv(defaultSystem, id); }
-function moduleRecordFor(id) { return _moduleRecordFor(defaultSystem, id); }
+function module(id) { return _module(defaultSystem, id); }
 function printSystemConfig() { return _printSystemConfig(defaultSystem); }
 export {
   defaultSystem as System,
@@ -252,10 +246,7 @@ export {
   loadedModules,
   printSystemConfig,
   changeSystem,
-  sourceOf,
-  searchModule,
-  moduleEnv,
-  moduleRecordFor
+  module
 }
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -295,20 +286,10 @@ export { moduleSourceChange };
 // dependencies
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 import {
-  findDependentsOf as _findDependentsOf,
-  findRequirementsOf as _findRequirementsOf,
-  forgetModule as _forgetModule,
-  reloadModule as _reloadModule,
   computeRequireMap
 } from './src/dependencies.js'
-import { importsAndExportsOf as _importsAndExportsOf } from './src/import-export.js';
-function findDependentsOf(module) { return _findDependentsOf(defaultSystem, module); }
-function findRequirementsOf(module) { return _findRequirementsOf(defaultSystem, module); }
-function forgetModule(module, opts) { return _forgetModule(defaultSystem, module, opts); }
-function reloadModule(module, opts) { return _reloadModule(defaultSystem, module, opts); }
 function requireMap() { return computeRequireMap(defaultSystem); }
-function importsAndExportsOf(moduleId, sourceOrAst) { return _importsAndExportsOf(defaultSystem, moduleId, sourceOrAst); }
-export { findDependentsOf, findRequirementsOf, forgetModule, reloadModule, requireMap, importsAndExportsOf }
+export { requireMap }
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // hooks

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -1,55 +1,6 @@
 import { graph, arr, obj } from "lively.lang";
 import { loadedModules } from "./system.js";
 
-export { computeRequireMap };
-
-function forgetEnvOf(System, fullname) {
-  delete System.get("@lively-env").loadedModules[fullname];
-}
-
-function forgetModuleDeps(System, moduleName, opts) {
-  opts = obj.merge({forgetDeps: true, forgetEnv: true}, opts);
-  var id = System.normalizeSync(moduleName),
-      deps = findDependentsOf(System, id);
-  deps.forEach(ea => {
-    System.delete(ea);
-    if (System.loads) delete System.loads[ea];
-    opts.forgetEnv && forgetEnvOf(System, ea);
-  });
-  return id;
-}
-
-function forgetModule(System, moduleName, opts) {
-  opts = obj.merge({forgetDeps: true, forgetEnv: true}, opts);
-  var id = opts.forgetDeps ?
-    forgetModuleDeps(System, moduleName, opts) :
-    System.normalizeSync(moduleName);
-  System.delete(moduleName);
-  System.delete(id);
-  if (System.loads) {
-    delete System.loads[moduleName];
-    delete System.loads[id];
-  }
-  if (System.meta) {
-    delete System.meta[moduleName];
-    delete System.meta[id];
-  }
-  if (opts.forgetEnv) {
-    forgetEnvOf(System, id);
-    forgetEnvOf(System, moduleName);
-  }
-}
-
-function reloadModule(System, moduleName, opts) {
-  opts = obj.merge({reloadDeps: true, resetEnv: true}, opts);
-  var id = System.normalizeSync(moduleName),
-      toBeReloaded = [id];
-  if (opts.reloadDeps) toBeReloaded = findDependentsOf(System, id).concat(toBeReloaded);
-  forgetModule(System, id, {forgetDeps: opts.reloadDeps, forgetEnv: opts.resetEnv});
-  return Promise.all(toBeReloaded.map(ea => ea !== id && System.import(ea)))
-          .then(() => System.import(id));
-}
-
 // function computeRequireMap() {
 //   return Object.keys(_currentSystem.loads).reduce((requireMap, k) => {
 //     requireMap[k] = lang.obj.values(_currentSystem.loads[k].depMap);
@@ -77,3 +28,5 @@ function computeRequireMap(System) {
     return requireMap;
   }, {});
 }
+
+export { computeRequireMap };

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -1,11 +1,7 @@
 import { graph, arr, obj } from "lively.lang";
 import { loadedModules } from "./system.js";
 
-export {
-  findDependentsOf, findRequirementsOf, computeRequireMap,
-  forgetModuleDeps, forgetModule,
-  reloadModule
-};
+export { computeRequireMap };
 
 function forgetEnvOf(System, fullname) {
   delete System.get("@lively-env").loadedModules[fullname];
@@ -80,27 +76,4 @@ function computeRequireMap(System) {
     requireMap[k] = System._loader.moduleRecords[k].dependencies.filter(Boolean).map(ea => ea.name);
     return requireMap;
   }, {});
-}
-
-function findDependentsOf(System, name) {
-  // which modules (module ids) are (in)directly import module with id
-  // Let's say you have
-  // module1: export var x = 23;
-  // module2: import {x} from "module1.js"; export var y = x + 1;
-  // module3: import {y} from "module2.js"; export var z = y + 1;
-  // `findDependentsOf` gives you an answer what modules are "stale" when you
-  // change module1 = module2 + module3
-  var id = System.normalizeSync(name);
-  return graph.hull(graph.invert(computeRequireMap(System)), id);
-}
-
-function findRequirementsOf(System, name) {
-  // which modules (module ids) are (in)directly required by module with id
-  // Let's say you have
-  // module1: export var x = 23;
-  // module2: import {x} from "module1.js"; export var y = x + 1;
-  // module3: import {y} from "module2.js"; export var z = y + 1;
-  // `findRequirementsOf("./module3")` will report ./module2 and ./module1
-  var id = System.normalizeSync(name);
-  return graph.hull(computeRequireMap(System), id);
 }

--- a/src/import-export.js
+++ b/src/import-export.js
@@ -1,10 +1,10 @@
 import * as ast from "lively.ast";
 import { arr } from "lively.lang"
-import { moduleRecordFor, updateModuleRecordOf, sourceOf } from "./system.js"
+import { module } from "./system.js"
 
 function scheduleModuleExportsChange(System, moduleId, name, value, addNewExport) {
   var pendingExportChanges = System.get("@lively-env").pendingExportChanges,
-      rec = moduleRecordFor(System, moduleId);
+      rec = module(System, moduleId).record;
   if (rec && (name in rec.exports || addNewExport)) {
     var pending = pendingExportChanges[moduleId] || (pendingExportChanges[moduleId] = {});
     pending[name] = value;
@@ -26,7 +26,7 @@ function clearPendingModuleExportChanges(System, moduleId) {
 
 function updateModuleExports(System, moduleId, keysAndValues) {
   var debug = System.debug;
-  updateModuleRecordOf(System, moduleId, (record) => {
+  module(System, moduleId).updateRecord((record) => {
 
     var newExports = [], existingExports = [];
 
@@ -82,100 +82,7 @@ function updateModuleExports(System, moduleId, keysAndValues) {
         }
       }
     }
-
   });
 }
 
-
-function importsAndExportsOf(System, moduleId, sourceOrAst) {
-  var parsed = typeof sourceOrAst === "string" ?
-        ast.parse(sourceOrAst) : sourceOrAst,
-      scope = ast.query.scopes(parsed);
-
-  // compute imports
-  var imports = scope.importDecls.reduce((imports, node) => {
-    var nodes = ast.query.nodesAtIndex(parsed, node.start);
-    var importStmt = arr.without(nodes, scope.node)[0];
-    if (!importStmt) return imports;
-
-    var from = importStmt.source ? importStmt.source.value : "unknown module";
-    if (!importStmt.specifiers.length) // no imported vars
-      return imports.concat([{
-        local:           null,
-        imported:        null,
-        fromModule:      from
-      }]);
-
-    return imports.concat(importStmt.specifiers.map(importSpec => {
-      var imported;
-      if (importSpec.type === "ImportNamespaceSpecifier") imported = "*";
-      else if (importSpec.type === "ImportDefaultSpecifier" ) imported = "default";
-      else if (importSpec.type === "ImportSpecifier" ) imported = importSpec.imported.name;
-      else if (importStmt.source) imported = importStmt.source.name;
-      else imported = null;
-      return {
-        local:           importSpec.local ? importSpec.local.name : null,
-        imported:        imported,
-        fromModule:      from
-      }
-    }))
-  }, []);
-
-  var exports = scope.exportDecls.reduce((exports, node) => {
-
-    var exportsStmt = ast.query.statementOf(scope.node, node);
-    if (!exportsStmt) return exports;
-
-    var from = exportsStmt.source ? exportsStmt.source.value : null;
-
-    if (exportsStmt.type === "ExportAllDeclaration") {
-      return exports.concat([{
-        local:           null,
-        exported:        "*",
-        fromModule:      from
-      }])
-    }
-
-    if (exportsStmt.specifiers && exportsStmt.specifiers.length) {
-      return exports.concat(exportsStmt.specifiers.map(exportSpec => {
-        return {
-          local:           from ? null : exportSpec.local ? exportSpec.local.name : null,
-          exported:        exportSpec.exported ? exportSpec.exported.name : null,
-          fromModule:      from
-        }
-      }))
-    }
-
-    if (exportsStmt.declaration && exportsStmt.declaration.declarations) {
-      return exports.concat(exportsStmt.declaration.declarations.map(decl => {
-        return {
-          local:           decl.id.name,
-          exported:        decl.id.name,
-          type:            exportsStmt.declaration.kind,
-          fromModule:      null
-        }
-      }))
-    }
-
-    if (exportsStmt.declaration) {
-      return exports.concat({
-        local:           exportsStmt.declaration.id.name,
-        exported:        exportsStmt.declaration.id.name,
-        type:            exportsStmt.declaration.type === "FunctionDeclaration" ?
-                          "function" : exportsStmt.declaration.type === "ClassDeclaration" ?
-                            "class" : null,
-        fromModule:      null
-      })
-    }
-
-    return exports;
-
-  }, []);
-
-  return {
-    imports: arr.uniqBy(imports, (a, b) => a.local == b.local && a.imported == b.imported && a.fromModule == b.fromModule),
-    exports: arr.uniqBy(exports, (a, b) => a.local == b.local && a.exported == b.exported && a.fromModule == b.fromModule)
-  }
-}
-
-export { runScheduledExportChanges, scheduleModuleExportsChange, importsAndExportsOf };
+export { runScheduledExportChanges, scheduleModuleExportsChange };

--- a/src/instrumentation.js
+++ b/src/instrumentation.js
@@ -1,6 +1,6 @@
 import { parse, evalSupport } from "lively.ast";
 import { arr, string, properties, classHelper } from "lively.lang";
-import { moduleEnv } from "./system.js";
+import { module } from "./system.js";
 import { install as installHook, remove as removeHook, isInstalled as isHookInstalled } from "./hooks.js";
 
 var evalCodeTransform = evalSupport.evalCodeTransform;
@@ -154,7 +154,7 @@ function customTranslate(proceed, load) {
            || (!load.metadata.format && !cjsFormatCommentRegExp.test(load.source.slice(0,5000)) && esmRegEx.test(load.source)),
       isCjs = load.metadata.format == 'cjs',
       isGlobal = load.metadata.format == 'global' || !load.metadata.format,
-      env = moduleEnv(System, load.name),
+      env = module(System, load.name).env,
       instrumented = false;
 
   if (isEsm) {

--- a/src/module.js
+++ b/src/module.js
@@ -1,0 +1,51 @@
+
+// Module class is primarily used to provide a nice API
+// It does not hold any mutable state
+export default class Module {
+  constructor(System, id) {
+    this.System = System;
+    this.id = id;
+  }
+  
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  // module records
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  
+  get record() {
+    const record = this.System._loader.moduleRecords[this.id];
+    if (!record) return null;
+    if (!record.hasOwnProperty("__lively_modules__"))
+      record.__lively_modules__ = {evalOnlyExport: {}};
+    return record;
+  }
+  
+  updateModuleRecordOf(doFunc) {
+    var record = this.record;
+    if (!record) throw new Error(`es6 environment global of ${this.id}: module not loaded, cannot get export object!`);
+    record.locked = true;
+    try {
+      return doFunc(record);
+    } finally { record.locked = false; }
+  }
+  
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  // search
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  
+  async search(searchStr) {
+    const src = await this.source();
+    const re = new RegExp(searchStr, "g");
+    let match, res = [];
+    while ((match = re.exec(src)) !== null) {
+      res.push(match.index);
+    }
+    for (let i = 0, j = 0, line = 1; i < src.length && j < res.length; i++) {
+      if (src[i] == '\n') line++;
+      if (i == res[j]) {
+        res[j] = this.id + ":" + line;
+        j++;
+      }
+    }
+    return res;
+  }
+}

--- a/src/module.js
+++ b/src/module.js
@@ -1,3 +1,5 @@
+import { graph } from "lively.lang";
+import { computeRequireMap } from './dependencies.js';
 
 // Module class is primarily used to provide a nice API
 // It does not hold any mutable state
@@ -5,6 +7,94 @@ export default class Module {
   constructor(System, id) {
     this.System = System;
     this.id = id;
+  }
+  
+  source(parent) {
+    if (this.id.match(/^http/) && this.System.global.fetch) {
+      return this.System.global.fetch(this.id).then(res => res.text());
+    }
+    if (this.id.match(/^file:/) && this.System.get("@system-env").node) {
+      const path = this.id.replace(/^file:\/\//, "");
+      return new Promise((resolve, reject) =>
+        this.System._nodeRequire("fs").readFile(path, (err, content) =>
+          err ? reject(err) : resolve(String(content))));
+    }
+    return Promise.reject(new Error(`Cannot retrieve source for ${this.id}`));
+  }
+  
+  get metadata() {
+    var load = this.System.loads ? this.System.loads[this.id] : null;
+    return load ? load.metadata : null;
+  }
+  
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  // dependencies
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  
+  get dependents() {
+    // which modules (module ids) are (in)directly import module with id
+    // Let's say you have
+    // module1: export var x = 23;
+    // module2: import {x} from "module1.js"; export var y = x + 1;
+    // module3: import {y} from "module2.js"; export var z = y + 1;
+    // `findDependentsOf` gives you an answer what modules are "stale" when you
+    // change module1 = module2 + module3
+    return graph.hull(graph.invert(computeRequireMap(this.System)), this.id);
+  }
+
+  get requirementsOf() {
+    // which modules (module ids) are (in)directly required by module with id
+    // Let's say you have
+    // module1: export var x = 23;
+    // module2: import {x} from "module1.js"; export var y = x + 1;
+    // module3: import {y} from "module2.js"; export var z = y + 1;
+    // `findRequirementsOf("./module3")` will report ./module2 and ./module1
+    return graph.hull(computeRequireMap(this.System), this.id);
+  }
+  
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  // module environment
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+  get env() {
+    const ext = this.System.get("@lively-env");
+    if (ext.loadedModules[this.id]) return ext.loadedModules[this.id];
+  
+    const env = {
+      loadError: undefined,
+      recorderName: "__lvVarRecorder",
+      dontTransform: [
+        "__lvVarRecorder",
+        "global", "self",
+        "_moduleExport", "_moduleImport",
+        "fetch" // doesn't like to be called as a method, i.e. __lvVarRecorder.fetch
+      ].concat(ast.query.knownGlobals),
+      recorder: Object.create(this.System.global, {
+        _moduleExport: {
+          get() {
+            return (name, val) => {
+              scheduleModuleExportsChange(this.System, this.id, name, val, true/*add export*/);
+            }
+          }
+        },
+        _moduleImport: {
+          get: function() {
+            return (imported, name) => {
+              var id = this.System.normalizeSync(imported, this.id),
+                  imported = this.System._loader.modules[id];
+              if (!imported) throw new Error(`import of ${name} failed: ${imported} (tried as ${id}) is not loaded!`);
+              if (name == undefined) return imported.module;
+              if (!imported.module.hasOwnProperty(name))
+                console.warn(`import from ${imported}: Has no export ${name}!`);
+              return imported.module[name];
+            }
+          }
+        }
+      })
+    }
+  
+    env.recorder.System = this.System;
+    return ext.loadedModules[this.id] = env;
   }
   
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/src/packages.js
+++ b/src/packages.js
@@ -1,7 +1,7 @@
 import { arr, string, promise } from "lively.lang";
 import { install as installHook, isInstalled as isHookInstalled } from "./hooks.js";
-
-import { computeRequireMap as requireMap, forgetModule } from './dependencies.js'
+import { module } from './system.js';
+import { computeRequireMap as requireMap } from './dependencies.js'
 
 // helper
 function isJsFile(url) { return /\.js/i.test(url); }
@@ -80,7 +80,7 @@ function removePackage(System, packageURL) {
   var p = getPackages(System)[packageURL]
   if (p)
     p.modules.forEach(mod =>
-      forgetModule(System, mod.name, {forgetEnv: true, forgetDeps: false}));
+      module(System, mod.name).unload({forgetEnv: true, forgetDeps: false}));
 
   System.config({
     meta: {[packageConfigURL]: {}},
@@ -299,15 +299,14 @@ function groupIntoPackages(System, moduleNames, packageNames) {
 }
 
 function getPackages(System) {
-  // returns a map like
+  // returns a list like
   // ```
-  // {
-  // package-address: {
+  // [{
   //   address: package-address,
   //   modules: [module-name-1, module-name-2, ...],
   //   name: package-name,
   //   names: [package-name, ...]
-  // }, ...
+  // }, ... ]
   // ```
 
   var map = requireMap(System),
@@ -315,7 +314,7 @@ function getPackages(System) {
       sysPackages = System.packages,
       livelyPackages = System.get("@lively-env").packages,
       packageNames = lively.lang.arr.uniq(Object.keys(sysPackages).concat(Object.keys(livelyPackages))),
-      result = {};
+      result = [];
 
   groupIntoPackages(System, modules, packageNames).mapGroups((packageAddress, moduleNames) => {
     var systemP = sysPackages[packageAddress],
@@ -326,7 +325,7 @@ function getPackages(System) {
 
     moduleNames = moduleNames.filter(name => name !== packageAddress && name !== packageAddress + "/")
 
-    result[packageAddress] = {
+    result.push(Object.assign(p || {}, {
       address: packageAddress,
       name: names[0],
       names: names,
@@ -334,7 +333,7 @@ function getPackages(System) {
         name: name,
         deps: map[name]
       }))
-    }
+    }));
   });
 
   return result;

--- a/src/system.js
+++ b/src/system.js
@@ -2,6 +2,7 @@ import * as ast from "lively.ast";
 import { obj, properties } from "lively.lang";
 import { scheduleModuleExportsChange, runScheduledExportChanges } from "./import-export.js";
 import { install as installHook, isInstalled as isHookInstalled } from "./hooks.js";
+import Module from "./module.js";
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
@@ -281,45 +282,6 @@ function printSystemConfig(System) {
 
 function loadedModules(System) { return System.get("@lively-env").loadedModules; }
 
-function moduleEnv(System, moduleId) {
-  var ext = System.get("@lively-env");
-
-  if (ext.loadedModules[moduleId]) return ext.loadedModules[moduleId];
-
-  var env = {
-    loadError: undefined,
-    recorderName: "__lvVarRecorder",
-    dontTransform: [
-        "__lvVarRecorder",
-        "global", "self",
-        "_moduleExport", "_moduleImport",
-        "fetch" // doesn't like to be called as a method, i.e. __lvVarRecorder.fetch
-      ].concat(ast.query.knownGlobals),
-    recorder: Object.create(System.global, {
-      _moduleExport: {
-        get() { return (name, val) => scheduleModuleExportsChange(System, moduleId, name, val, true/*add export*/); }
-      },
-      _moduleImport: {
-        get: function() {
-          return (imported, name) => {
-            var id = System.normalizeSync(imported, moduleId),
-                imported = System._loader.modules[id];
-            if (!imported) throw new Error(`import of ${name} failed: ${imported} (tried as ${id}) is not loaded!`);
-            if (name == undefined) return imported.module;
-            if (!imported.module.hasOwnProperty(name))
-              console.warn(`import from ${imported}: Has no export ${name}!`);
-            return imported.module[name];
-          }
-        }
-      }
-    })
-  }
-
-  env.recorder.System = System;
-
-  return ext.loadedModules[moduleId] = env;
-}
-
 function addGetterSettersForNewVars(System, moduleId) {
   // after eval we modify the env so that all captures vars are wrapped in
   // getter/setter to be notified of changes
@@ -350,67 +312,10 @@ function addGetterSettersForNewVars(System, moduleId) {
   });
 }
 
-function sourceOf(System, moduleName, parent) {
-  return System.normalize(moduleName, parent)
-    .then(id => {
-      if (id.match(/^http/) && System.global.fetch) {
-        return System.global.fetch(id).then(res => res.text())
-      }
-      if (id.match(/^file:/) && System.get("@system-env").node) {
-        return new Promise((resolve, reject) =>
-          System._nodeRequire("fs").readFile(id.replace(/^file:\/\//, ""), (err, content) =>
-            err ? reject(err) : resolve(String(content))))
-      }
-      return Promise.reject(new Error(`Cannot retrieve source for ${id}`));
-    });
-}
-
-function metadata(System, moduleId) {
-  var load = System.loads ? System.loads[moduleId] : null;
-  return load ? load.metadata : null;
-}
-
-// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-// module records
-// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-
-function moduleRecordFor(System, fullname) {
-  var record = System._loader.moduleRecords[fullname];
-  if (!record) return null;
-  if (!record.hasOwnProperty("__lively_modules__"))
-    record.__lively_modules__ = {evalOnlyExport: {}};
-  return record;
-}
-
-function updateModuleRecordOf(System, fullname, doFunc) {
-  var record = moduleRecordFor(System, fullname);
-  if (!record) throw new Error(`es6 environment global of ${fullname}: module not loaded, cannot get export object!`);
-  record.locked = true;
-  try {
-    return doFunc(record);
-  } finally { record.locked = false; }
-}
-
-// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-// search
-// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-
-async function searchModule(System, moduleName, searchStr) {
-  const src = await sourceOf(System, moduleName);
-  const id = await System.normalize(moduleName);
-  const re = new RegExp(searchStr, "g");
-  let match, res = [];
-  while ((match = re.exec(src)) !== null) {
-    res.push(match.index);
-  }
-  for (let i = 0, j = 0, line = 1; i < src.length && j < res.length; i++) {
-    if (src[i] == '\n') line++;
-    if (i == res[j]) {
-      res[j] = id + ":" + line;
-      j++;
-    }
-  }
-  return res;
+function module(System, moduleName) {
+  const m = new Module(System, moduleName);
+  Object.freeze(m);
+  return m;
 }
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -420,7 +325,5 @@ async function searchModule(System, moduleName, searchStr) {
 export {
   getSystem, removeSystem, prepareSystem,
   printSystemConfig,
-  moduleRecordFor, updateModuleRecordOf,
-  loadedModules, moduleEnv, metadata,
-  sourceOf, searchModule
+  loadedModules, module
 };

--- a/src/system.js
+++ b/src/system.js
@@ -18,7 +18,7 @@ var defaultOptions = {
 
 function livelySystemEnv(System) {
   return {
-    moduleEnv: function(id) { return moduleEnv(System, id); },
+    moduleEnv: function(id) { return module(System, id).env; },
 
     // TODO this is just a test, won't work in all cases...
     get itself() { return System.get(System.normalizeSync("lively.modules/index.js")); },
@@ -286,7 +286,7 @@ function addGetterSettersForNewVars(System, moduleId) {
   // after eval we modify the env so that all captures vars are wrapped in
   // getter/setter to be notified of changes
   // FIXME: better to not capture via assignments but use func calls...!
-  var rec = moduleEnv(System, moduleId).recorder,
+  var rec = module(System, moduleId).env.recorder,
       prefix = "__lively.modules__";
 
   if (rec === System.global) {
@@ -312,10 +312,8 @@ function addGetterSettersForNewVars(System, moduleId) {
   });
 }
 
-function module(System, moduleName) {
-  const m = new Module(System, moduleName);
-  Object.freeze(m);
-  return m;
+function module(System, moduleName, parent) {
+  return new Module(System, System.normalizeSync(moduleName, parent));
 }
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/tests/imports-exports-test.js
+++ b/tests/imports-exports-test.js
@@ -3,8 +3,7 @@
 import { expect } from "mocha-es6";
 import { removeDir, createFiles } from "./helpers.js";
 
-import { getSystem, removeSystem, sourceOf } from "../src/system.js";
-import { importsAndExportsOf } from "../src/import-export.js";
+import { getSystem, removeSystem, module } from "../src/system.js";
 
 var dir = System.normalizeSync("lively.modules/tests/"),
     testProjectDir = dir + "test-dir-imports-exports/",
@@ -17,68 +16,71 @@ var dir = System.normalizeSync("lively.modules/tests/"),
       "file6.js": "export function bar() {}",
       "file7.js": "export class Baz {}",
       "package.json": '{"name": "imports-exports-test-project", "main": "file1.js"}'
-    },
-    module1 = testProjectDir + "file1.js",
-    module2 = testProjectDir + "file2.js",
-    module3 = testProjectDir + "file3.js",
-    module4 = testProjectDir + "file4.js",
-    module5 = testProjectDir + "file5.js",
-    module6 = testProjectDir + "file6.js",
-    module7 = testProjectDir + "file7.js";
+    };
 
 describe("imports and exports", () => {
 
-  var S;
-  beforeEach(() => (S = getSystem('import-export-test')) && createFiles(testProjectDir, testProjectSpec));
+  var S, module1, module2, module3, module4, module5, module6, module7;
+  beforeEach(() => {
+    S = getSystem('import-export-test');
+    module1 = module(S, testProjectDir + "file1.js"),
+    module2 = module(S, testProjectDir + "file2.js"),
+    module3 = module(S, testProjectDir + "file3.js"),
+    module4 = module(S, testProjectDir + "file4.js"),
+    module5 = module(S, testProjectDir + "file5.js"),
+    module6 = module(S, testProjectDir + "file6.js"),
+    module7 = module(S, testProjectDir + "file7.js");
+    return createFiles(testProjectDir, testProjectSpec)
+  });
   afterEach(() => removeDir(testProjectDir));
 
   it("exports of var decls", async () => {
-    var result = await importsAndExportsOf(S, module1, await sourceOf(S,module1));
-    expect(result.exports).to.have.length(1);
-    expect(result.exports[0]).to.containSubset({exported: "x", local: "x", type: "var"});
+    var result = await module1.exports();
+    expect(result).to.have.length(1);
+    expect(result[0]).to.containSubset({exported: "x", local: "x", type: "var"});
   });
 
   it("exports * from", async () => {
-    var result = await importsAndExportsOf(S, module4, await sourceOf(S,module4));
-    expect(result.exports).to.have.length(1);
-    expect(result.exports[0]).to.containSubset({exported: "*", fromModule: "./file1.js", local: null});
+    var result = await module4.exports();
+    expect(result).to.have.length(1);
+    expect(result[0]).to.containSubset({exported: "*", fromModule: "./file1.js", local: null});
   });
 
   it("exports named from", async () => {
-    var result = await importsAndExportsOf(S, module3, await sourceOf(S,module3));
-    expect(result.exports).to.have.length(1);
-    expect(result.exports[0]).to.containSubset({exported: "x", fromModule: "./file1.js", local: null});
+    var result = await module3.exports();
+    expect(result).to.have.length(1);
+    expect(result[0]).to.containSubset({exported: "x", fromModule: "./file1.js", local: null});
   });
 
   it("exports functions", async () => {
-    var result = await importsAndExportsOf(S, module6, await sourceOf(S,module6));
-    expect(result.exports).to.have.length(1);
-    expect(result.exports[0]).to.containSubset({exported: "bar", local: "bar", type: "function"});
+    var result = await module6.exports();
+    expect(result).to.have.length(1);
+    expect(result[0]).to.containSubset({exported: "bar", local: "bar", type: "function"});
   });
 
   it("exports default function", async () => {
-    var result = await importsAndExportsOf(S, module5, await sourceOf(S,module5));
-    expect(result.exports).to.have.length(1);
-    expect(result.exports[0]).to.containSubset({exported: "foo", local: "foo", type: "function"});
+    var result = await module5.exports();
+    expect(result).to.have.length(1);
+    expect(result[0]).to.containSubset({exported: "foo", local: "foo", type: "function"});
   });
 
   it("exports class", async () => {
-    var result = await importsAndExportsOf(S, module7, await sourceOf(S,module7));
-    expect(result.exports).to.have.length(1);
-    expect(result.exports[0]).to.containSubset({exported: "Baz", local: "Baz", type: "class"});
+    var result = await module7.exports();
+    expect(result).to.have.length(1);
+    expect(result[0]).to.containSubset({exported: "Baz", local: "Baz", type: "class"});
   });
 
   it("imports of named vars", async () => {
-    var result = await importsAndExportsOf(S, module1, await sourceOf(S,module1));
-    expect(result.imports).to.have.length(1);
-    expect(result.imports[0]).to.containSubset({fromModule: "./file2.js", imported: 'y', local: "yyy"});
+    var result = await module1.imports();
+    expect(result).to.have.length(1);
+    expect(result[0]).to.containSubset({fromModule: "./file2.js", imported: 'y', local: "yyy"});
   });
 
 
   it("imports *", async () => {
-    var result = await importsAndExportsOf(S, module4, await sourceOf(S,module4));
-    expect(result.imports).to.have.length(1);
-    expect(result.imports[0]).to.containSubset({fromModule: "./file2.js", imported: "*", local: "file2"});
+    var result = await module4.imports();
+    expect(result).to.have.length(1);
+    expect(result[0]).to.containSubset({fromModule: "./file2.js", imported: "*", local: "file2"});
   });
 
 })

--- a/tests/instrumentation-test.js
+++ b/tests/instrumentation-test.js
@@ -3,7 +3,7 @@
 import { expect } from "mocha-es6";
 import { removeDir, createFiles, inspect as i } from "./helpers.js";
 
-import { getSystem, removeSystem, moduleEnv } from "../src/system.js";
+import { getSystem, removeSystem, module } from "../src/system.js";
 
 var dir = System.normalizeSync("lively.modules/tests/"),
     testProjectDir = dir + "test-project-dir/",
@@ -22,9 +22,13 @@ var dir = System.normalizeSync("lively.modules/tests/"),
 
 describe("instrumentation", () => {
 
-  var S;
+  let S, module1, module2, module3, module4;
   beforeEach(() => {
     S = getSystem("test", {baseURL: dir});
+    module1 = module(S, testProjectDir + "file1.js");
+    module2 = module(S, testProjectDir + "file2.js");
+    module3 = module(S, testProjectDir + "file3.js");
+    module4 = module(S, testProjectDir + "file4.js");
     try { delete S.global.z; } catch (e) {}
     try { delete S.global.zzz; } catch (e) {}
     return createFiles(testProjectDir, testProjectSpec)
@@ -37,9 +41,8 @@ describe("instrumentation", () => {
   });
 
   it("gets access to internal module state", () => {
-    var env = moduleEnv(S, testProjectDir + "file1.js");
-    expect(env).to.have.deep.property("recorder.y", 1);
-    expect(env).to.have.deep.property("recorder.x", 3);
+    expect(module1.env).to.have.deep.property("recorder.y", 1);
+    expect(module1.env).to.have.deep.property("recorder.x", 3);
   });
 
   describe("of global modules", () => {
@@ -47,8 +50,7 @@ describe("instrumentation", () => {
     it("can access local state", () => 
       S.import(`${testProjectDir}file3.js`)
         .then(() => {
-          var env = moduleEnv(S, `${testProjectDir}file3.js`);
-          expect(env).to.have.deep.property("recorder.zzz", 4);
+          expect(module3.env).to.have.deep.property("recorder.zzz", 4);
           expect(S.get(testProjectDir + "file3.js")).to.have.property("z", 2);
         }))
 
@@ -59,8 +61,7 @@ describe("instrumentation", () => {
     it("class export is recorded", () =>
       S.import(`${testProjectDir}file4.js`)
         .then(() => {
-          var env = moduleEnv(S, `${testProjectDir}file4.js`);
-          expect(env).to.have.deep.property("recorder.Foo");
+          expect(module4.env).to.have.deep.property("recorder.Foo");
         }));
   });
 

--- a/tests/module-dependency-test.js
+++ b/tests/module-dependency-test.js
@@ -3,8 +3,7 @@
 import { expect } from "mocha-es6";
 import { removeDir, createFiles } from "./helpers.js";
 
-import { getSystem, removeSystem, moduleRecordFor, moduleEnv } from "../src/system.js";
-import { findRequirementsOf, findDependentsOf, forgetModule } from "../src/dependencies.js";
+import { getSystem, removeSystem, module } from "../src/system.js";
 
 var dir = System.normalizeSync("lively.modules/tests/"),
     testProjectDir = dir + "test-project-1-dir/",
@@ -14,44 +13,43 @@ var dir = System.normalizeSync("lively.modules/tests/"),
       "package.json": '{"name": "test-project-1", "main": "file1.js", "systemjs": {"main": "file1.js"}}',
       "sub-dir": {"file3.js": "export var z = 2;"}
     },
-    module1 = testProjectDir + "file1.js",
-    module2 = testProjectDir + "file2.js",
-    module3 = testProjectDir + "sub-dir/file3.js";
+    file1m = testProjectDir + "file1.js",
+    file2m = testProjectDir + "file2.js",
+    file3m = testProjectDir + "sub-dir/file3.js";
 
 
 describe("dependencies", () => {
 
-  var System;
+  let S, module1, module2, module3;
   beforeEach(() => {
-    System = getSystem("test", {baseURL: testProjectDir});
+    S = getSystem("test", {baseURL: testProjectDir});
+    module1 = module(S, file1m);
+    module2 = module(S, file2m);
+    module3 = module(S, file3m);
     return createFiles(testProjectDir, testProjectSpec);
   });
 
   afterEach(() => { removeSystem("test"); return removeDir(testProjectDir); });
 
   it("computes required modules of some module", async () => {
-    await System.import("file1.js");
-    var reqs = findRequirementsOf(System, "file1.js");
-    expect(reqs).to.deep.equal([testProjectDir + "file2.js", testProjectDir + "sub-dir/file3.js"]);
+    await S.import("file1.js");
+    expect(module1.requirements).to.deep.equal([file2m, file3m]);
   });
 
   it("computes dependent modules of some module", async () => {
-    await System.import("file1.js");
-    var deps = findDependentsOf(System, "file2.js");
-    expect(deps).to.deep.equal([testProjectDir + "file1.js"]);
+    await S.import("file1.js");
+    expect(module2.dependents).to.deep.equal([file1m]);
   });
-
 
   describe("unload module", () => {
     
     it("forgets module and recordings", async () => {
-      await System.import(module1);
-      forgetModule(System, module2);
-      expect(moduleRecordFor(System, module1)).to.equal(null, "record for module1 still exists");
-      expect(moduleRecordFor(System, module2)).to.equal(null, "record for module2 still exists");
-      debugger;
-      expect(moduleEnv(System, module1).recorder).to.not.have.property("x");
-      expect(moduleEnv(System, module2).recorder).to.not.have.property("y");
+      await S.import(module1);
+      module2.forget();
+      expect(module1.record).to.equal(null, "record for module1 still exists");
+      expect(module2.record).to.equal(null, "record for module2 still exists");
+      expect(module1.env.recorder).to.not.have.property("x");
+      expect(module2.env.recorder).to.not.have.property("y");
     });
   
   });

--- a/tests/module-dependency-test.js
+++ b/tests/module-dependency-test.js
@@ -33,19 +33,19 @@ describe("dependencies", () => {
 
   it("computes required modules of some module", async () => {
     await S.import("file1.js");
-    expect(module1.requirements).to.deep.equal([file2m, file3m]);
+    expect(module1.requirements).to.deep.equal([module2, module3]);
   });
 
   it("computes dependent modules of some module", async () => {
     await S.import("file1.js");
-    expect(module2.dependents).to.deep.equal([file1m]);
+    expect(module2.dependents).to.deep.equal([module1]);
   });
 
   describe("unload module", () => {
     
     it("forgets module and recordings", async () => {
-      await S.import(module1);
-      module2.forget();
+      await S.import("file1.js");
+      await module2.unload();
       expect(module1.record).to.equal(null, "record for module1 still exists");
       expect(module2.record).to.equal(null, "record for module2 still exists");
       expect(module1.env.recorder).to.not.have.property("x");

--- a/tests/notify-test.js
+++ b/tests/notify-test.js
@@ -5,7 +5,6 @@ import { removeDir, createFiles } from "./helpers.js";
 
 import { getSystem, removeSystem } from "../src/system.js";
 // import { runEval } from "../src/eval.js";
-import { moduleSourceChangeAction } from "../src/change.js";
 import { getNotifications, subscribe, unsubscribe } from "../src/notify.js";
 
 var dir = System.normalizeSync("lively.modules/tests/"),

--- a/tests/package-loading-test.js
+++ b/tests/package-loading-test.js
@@ -4,7 +4,7 @@ import { expect } from "mocha-es6";
 import { removeDir, createFiles, modifyJSON, noTrailingSlash, inspect as i } from "./helpers.js";
 
 import { obj } from "lively.lang";
-import { getSystem, removeSystem, printSystemConfig, loadedModules, moduleEnv } from "../src/system.js";
+import { getSystem, removeSystem, printSystemConfig, loadedModules, module } from "../src/system.js";
 import { registerPackage, importPackage, applyConfig, getPackages } from "../src/packages.js";
 
 var testDir = System.normalizeSync("lively.modules/tests/");
@@ -59,13 +59,13 @@ describe("package loading", function() {
     it("registers and loads a package", async () => {
       await registerPackage(System, project1aDir);
       var mod = await System.import("some-project");
-      expect(mod).to.have.property("x", 2)
-      expect(System.get("@lively-env").packages).to.containSubset({
-        [noTrailingSlash(project1aDir)]: {
-          main: "entry-a.js",
-          meta: {"package.json": {format: "json"}},
-          map: {},
-          names: ["some-project"]}})
+      expect(mod).to.have.property("x", 2);
+      expect(getPackages(System)).to.containSubset([{
+        main: "entry-a.js",
+        meta: {"package.json": {format: "json"}},
+        map: {},
+        names: ["some-project"]
+      }]);
     });
 
     it("registers and loads dependent packages", async () => {
@@ -78,22 +78,22 @@ describe("package loading", function() {
 
     it("enumerates packages", async () => {
       await importPackage(System, project2Dir);
-      expect(getPackages(System)).to.containSubset({
-        [noTrailingSlash(project2Dir)]: {
+      expect(getPackages(System)).to.containSubset([
+        {
           address: noTrailingSlash(project2Dir),
           name: `dependent-project`, names: [`dependent-project`],
           modules: [
             {deps: [`${project1aDir}entry-a.js`], name: `${project2Dir}index.js`},
-            { deps: [], name: `${project2Dir}package.json`}],
+            {deps: [], name: `${project2Dir}package.json`}],
         },
-        [noTrailingSlash(project1aDir)]: {
+        {
           address: noTrailingSlash(project1aDir),
           name: `some-project`, names: [`some-project`],
           modules: [
             {deps: [`${project1aDir}other.js`], name: `${project1aDir}entry-a.js`},
             {deps: [],name: `${project1aDir}other.js`},
             {deps: [],name: `${project1aDir}package.json`}]
-        }})
+        }])
     })
   });
 
@@ -191,7 +191,7 @@ describe("mutual dependent packages", () => {
   it("can be imported", () =>
     importPackage(System, p1Dir)
       .then(() => {
-        expect(moduleEnv(System, `${p1Dir}index.js`).recorder).property("y").equals(2);
+        expect(module(System, `${p1Dir}index.js`).env.recorder).property("y").equals(2);
         // FIXME! see https://github.com/LivelyKernel/lively.modules/issues/6
         // expect(moduleEnv(System, `${p2Dir}index.js`).recorder).property("x").equals(3);
       }))

--- a/tests/package-loading-test.js
+++ b/tests/package-loading-test.js
@@ -61,6 +61,7 @@ describe("package loading", function() {
       var mod = await System.import("some-project");
       expect(mod).to.have.property("x", 2);
       expect(getPackages(System)).to.containSubset([{
+        address: noTrailingSlash(project1aDir),
         main: "entry-a.js",
         meta: {"package.json": {format: "json"}},
         map: {},

--- a/tests/search-test.js
+++ b/tests/search-test.js
@@ -3,7 +3,7 @@
 import { expect } from "mocha-es6";
 
 import { removeDir, createFiles } from "./helpers.js";
-import { getSystem, searchModule } from "../src/system.js";
+import { getSystem } from "../src/system.js";
 
 const dir = System.normalizeSync("lively.modules/tests/"),
       testProjectDir = dir + "test-project-dir/",
@@ -17,9 +17,11 @@ const dir = System.normalizeSync("lively.modules/tests/"),
 
 describe("search", () => {
 
-  let S;
+  let S, module1, module2;
   before(async () => {
     S = getSystem("test", {baseURL: dir});
+    module1 = module(S, file1m);
+    module2 = module(S, file2m);
     await createFiles(testProjectDir, testProjectSpec);
   })
 
@@ -30,12 +32,12 @@ describe("search", () => {
   describe("in modules", () => {
     
     it("finds string constants", async () => {
-      const res = await searchModule(S, file1m, "hello");
+      const res = await module1.search("hello");
       expect(res).to.be.deep.eql([file1m + ":2"]);
     })
     
     it("finds comments", async () => {
-      const res = await searchModule(S, file2m, "comment");
+      const res = await module2.search("comment");
       expect(res).to.be.deep.eql([file2m + ":1"]);
     })
   });

--- a/tests/search-test.js
+++ b/tests/search-test.js
@@ -3,7 +3,7 @@
 import { expect } from "mocha-es6";
 
 import { removeDir, createFiles } from "./helpers.js";
-import { getSystem } from "../src/system.js";
+import { getSystem, module } from "../src/system.js";
 
 const dir = System.normalizeSync("lively.modules/tests/"),
       testProjectDir = dir + "test-project-dir/",


### PR DESCRIPTION
This refactoring is mostly about the API and does not involve major changes to the implementation. However, having a module class should make it simpler to add more extensions, e.g. search, analysis, etc.
