### PR TITLE
Concurrent package loading

### DIFF
--- a/src/packages.js
+++ b/src/packages.js
@@ -368,6 +368,7 @@ function searchPackage(System, packageURL, searchStr, options) {
 }
 
 export {
+  getPackage,
   importPackage,
   registerPackage,
   removePackage,

--- a/src/packages.js
+++ b/src/packages.js
@@ -276,9 +276,9 @@ class Package {
     delete System.packages[url];
   }
 
-  reload() { return this.remove().then(() => this.import()); }
+  reload() { this.remove(); return this.import(); }
 
-  search(needle, options) { return searchPackage(this.System, this.packageURL, needle, options); }
+  search(needle, options) { return searchPackage(this.System, this.url, needle, options); }
 
 }
 

--- a/tests/package-loading-test.js
+++ b/tests/package-loading-test.js
@@ -8,49 +8,48 @@ import { getSystem, removeSystem, printSystemConfig, loadedModules } from "../sr
 import { registerPackage, importPackage, applyConfig, getPackages } from "../src/packages.js";
 import module from "../src/module.js";
 
-var testDir = System.decanonicalize("lively.modules/tests/");
+var testDir = System.decanonicalize("lively.modules/tests/package-tests-temp/");
 
+var project1aDir = testDir + "dep1/",
+    project1bDir = testDir + "dep2/",
+    project2Dir = testDir + "project2/",
+    project1a = {
+      "entry-a.js": "import { y } from './other.js'; var x = y + 1, version = 'a'; export { x, version };",
+      "other.js": "export var y = 1;",
+      "package.json": '{"name": "some-project", "main": "entry-a.js"}'
+    },
+    project1b = {
+      "entry-b.js": "var x = 23, version = 'b'; export { x, version };",
+      "package.json": '{"name": "some-project", "main": "entry-b.js"}'
+    },
+    project2 = {
+      "index.js": "export { x, version } from 'some-project';",
+      "package.json": JSON.stringify({
+        name: "project2", dependencies: {"some-project": "*"},
+        lively: {packageMap: {"some-project": project1bDir}}
+      })
+    },
+    testResources = {
+      "dep1": project1a,
+      "dep2": project1b,
+      "project2": project2
+    }
 
 describe("package loading", function() {
 
-  var project1aDir = testDir + "dep1/",
-      project1bDir = testDir + "dep2/",
-      project2Dir = testDir + "dependent-dir/",
-      project1a = {
-        "entry-a.js": "import { y } from './other.js'; var x = y + 1, version = 'a'; export { x, version };",
-        "other.js": "export var y = 1;",
-        "package.json": '{"name": "some-project", "main": "entry-a.js"}'
-      },
-      project1b = {
-        "entry-b.js": "var x = 23, version = 'b'; export { x, version };",
-        "package.json": '{"name": "some-project", "main": "entry-b.js"}'
-      },
-      project2 = {
-        "index.js": "export { x, version } from 'some-project';",
-        "package.json": JSON.stringify({
-          name: "dependent-project", dependencies: {"some-project": "*"},
-          lively: {packageMap: {"some-project": project1bDir}}
-        })
-      }
 
   var System;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     System = getSystem("test", {baseURL: testDir});
-    return Promise.all([
-      createFiles(project1aDir, project1a),
-      createFiles(project1bDir, project1b),
-      createFiles(project2Dir, project2)])
-        .then(_ => registerPackage(System, project1aDir))
+    await createFiles(testDir, testResources)
+    await registerPackage(System, project1aDir);
   });
 
   afterEach(() => {
     removeSystem("test")
     // show(printSystemConfig(System)) &&
-    return Promise.all([
-      removeDir(project1aDir),
-      removeDir(project1bDir),
-      removeDir(project2Dir)]);
+    return removeDir(testDir);;
   });
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -74,7 +73,7 @@ describe("package loading", function() {
       await Promise.all([
         registerPackage(System, project1bDir),
         registerPackage(System, project2Dir)]);
-      var mod = await System.import("dependent-project")
+      var mod = await System.import("project2")
       expect(mod).to.have.property("x", 23);
     });
 
@@ -83,7 +82,7 @@ describe("package loading", function() {
       expect(getPackages(System)).to.containSubset([
         {
           address: noTrailingSlash(project2Dir),
-          name: `dependent-project`, names: [`dependent-project`],
+          name: `project2`, names: [`project2`],
           modules: [
             {deps: [`${project1aDir}entry-a.js`], name: `${project2Dir}index.js`},
             {deps: [], name: `${project2Dir}package.json`}],
@@ -103,32 +102,74 @@ describe("package loading", function() {
 
   describe("with pre-loaded dependent packages", function() {
 
-    it("uses existing dependency by default", () =>
-      registerPackage(System, project2Dir)
-        .then(() => System.import("dependent-project"))
-        .then(m => expect(m.version).to.equal("a")));
+    it("uses existing dependency by default", async () => {
+      await registerPackage(System, project2Dir);
+      var m = await System.import("project2");
+      expect(m.version).to.equal("a");
+    });
 
-    it("uses specified dependency when preferLoaded is false", () =>
-      modifyJSON(project2Dir + "package.json", {lively: {preferLoadedPackages: false}})
-        .then(() => registerPackage(System, project2Dir))
-        .then(() => System.import("dependent-project"))
-        .then(m => expect(m.version).to.equal("b")));
+    it("uses specified dependency when preferLoaded is false", async () => {
+      await modifyJSON(project2Dir + "package.json", {lively: {preferLoadedPackages: false}});
+      await registerPackage(System, project2Dir);
+      var m = await System.import("project2");
+      expect(m.version).to.equal("b");
+    });
 
-    it("deals with package map directory entry", () =>
-      modifyJSON(project2Dir + "package.json", {lively: {preferLoadedPackages: false, packageMap: {"some-project": project1bDir}}})
-        .then(() => registerPackage(System, project2Dir))
-        .then(() => System.import("dependent-project"))
-        .then(m => expect(m.version).to.equal("b")));
+    it("deals with package map directory entry", async () => {
+      await modifyJSON(project2Dir + "package.json", {lively: {preferLoadedPackages: false, packageMap: {"some-project": project1bDir}}});
+      await registerPackage(System, project2Dir);
+      var m = await System.import("project2");
+      expect(m.version).to.equal("b")
+    });
 
-    it("deals with package map relative entry", () =>
-      modifyJSON(project2Dir + "package.json", {lively: {preferLoadedPackages: false, packageMap: {"some-project": "../dep2/"}}})
-        .then(() => registerPackage(System, project2Dir))
-        .then(() => expect(System.packages).to.containSubset({
-          [noTrailingSlash(project1bDir)]: {main: "entry-b.js", map: {}, names: ["some-project"]},
-          [noTrailingSlash(project2Dir)]: {map: {"some-project": "../dep2/"}, names: ["dependent-project"]}
-        }))
-        .then(() => System.import("dependent-project"))
-        .then(m => expect(m.version).to.equal("b")));
+    it("deals with package map relative entry", async () => {
+      await modifyJSON(project2Dir + "package.json", {lively: {preferLoadedPackages: false, packageMap: {"some-project": "../dep2/"}}});
+      await registerPackage(System, project2Dir);
+      expect(System.packages).to.containSubset({
+        [noTrailingSlash(project1bDir)]: {main: "entry-b.js", map: {}, names: ["some-project"]},
+        [noTrailingSlash(project2Dir)]: {map: {"some-project": "../dep2/"}, names: ["project2"]}
+      });
+      var m = await System.import("project2");
+      expect(m.version).to.equal("b");
+    });
+
+    it("Concurrent loading will not load multiple versions", async () => {
+      var project3Dir = testDir + "project3/",
+          project3 = {
+            "index.js": "export { x, version } from 'some-project';",
+            "package.json": JSON.stringify({
+              name: "project2", dependencies: {"some-project": "*"},
+              lively: {packageMap: {"some-project": project1aDir}}
+            })
+          },
+          project4Dir = testDir + "project4/",
+          project4 = {
+            "index.js": "export { version } from 'some-project';",
+            "package.json": JSON.stringify({
+              name: "project2", dependencies: {"some-project": "*"},
+              lively: {packageMap: {"some-project": project1cDir}}
+            })
+          },
+          project5Dir = testDir + "project5/",
+          project5 = {
+            "index.js": "export { version } from 'project2';",
+            "package.json": JSON.stringify({
+              name: "project5", dependencies: {"project2": "*"},
+              lively: {packageMap: {"project2": project4Dir}}
+            })
+          },
+          project1cDir = testDir + "project1c/",
+          project1c = {"entry-c.js": "var version = 'c';\n", "package.json": '{"name": "some-project", "main": "entry-c.js"}'}
+      await createFiles(project1cDir, project1c);
+      await createFiles(project3Dir, project3);
+      await createFiles(project4Dir, project4);
+      await createFiles(project5Dir, project5);
+      await Promise.all([
+        importPackage(System, project2Dir),
+        importPackage(System, project3Dir),
+        importPackage(System, project5Dir)]);
+      console.log(getPackages(System).map(ea => ea.address).join("\n"))
+    });
 
   });
 
@@ -176,18 +217,22 @@ describe("mutual dependent packages", () => {
       p2 = {
         "index.js": "export var y = 2; import { x } from 'p1';",
         "package.json": '{"name": "p2", "lively": {"packageMap": {"p1": "../p1"}}}'
-      };
+      },
+      testResources = {p1, p2}
 
   var System;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     System = getSystem("test", {baseURL: testDir});
     System.debug = true;
-    return Promise.all([createFiles(p1Dir, p1),createFiles(p2Dir, p2)]);
+    await createFiles(testDir, testResources);
   });
 
 
-  afterEach(() => { removeSystem("test"); return Promise.all([removeDir(p1Dir),removeDir(p2Dir)]); });
+  afterEach(async () => {
+    removeSystem("test")
+    await removeDir(testDir);
+  });
 
 
   it("can be imported", async () => {

--- a/tests/package-loading-test.js
+++ b/tests/package-loading-test.js
@@ -63,7 +63,7 @@ describe("package loading", function() {
         main: "entry-a.js",
         meta: {"package.json": {format: "json"}},
         map: {},
-        names: ["some-project"]
+        referencedAs: ["some-project"]
       }]);
     });
 
@@ -80,14 +80,14 @@ describe("package loading", function() {
       expect(getPackages(S)).to.containSubset([
         {
           address: noTrailingSlash(project2Dir),
-          name: `project2`, names: [`project2`],
+          name: `project2`, referencedAs: [`project2`],
           modules: [
             {deps: [`${project1aDir}entry-a.js`], name: `${project2Dir}index.js`},
             {deps: [], name: `${project2Dir}package.json`}],
         },
         {
           address: noTrailingSlash(project1aDir),
-          name: `some-project`, names: [`some-project`],
+          name: `some-project`, referencedAs: [`some-project`],
           modules: [
             {deps: [`${project1aDir}other.js`], name: `${project1aDir}entry-a.js`},
             {deps: [],name: `${project1aDir}other.js`},
@@ -124,8 +124,8 @@ describe("package loading", function() {
       await modifyJSON(project2Dir + "package.json", {lively: {preferLoadedPackages: false, packageMap: {"some-project": "../dep2/"}}});
       await getPackage(S, project2Dir).register();
       expect(S.packages).to.containSubset({
-        [noTrailingSlash(project1bDir)]: {main: "entry-b.js", map: {}, names: ["some-project"]},
-        [noTrailingSlash(project2Dir)]: {map: {"some-project": "../dep2/"}, names: ["project2"]}
+        [noTrailingSlash(project1bDir)]: {main: "entry-b.js", map: {}, referencedAs: ["some-project"]},
+        [noTrailingSlash(project2Dir)]: {map: {"some-project": "../dep2/"}, referencedAs: ["project2"]}
       });
       var m = await S.import("project2");
       expect(m.version).to.equal("b");

--- a/tests/package-loading-test.js
+++ b/tests/package-loading-test.js
@@ -151,10 +151,12 @@ describe("package loading", function() {
       await createFiles(project2bDir, project2b);
       await createFiles(project5Dir, project5);
       await Promise.all([
-        importPackage(S, project2Dir),
-        importPackage(S, project5Dir)
-        ]);
-      console.log(getPackages(S).map(ea => ea.address).join("\n"))
+        getPackage(S, project2Dir).import(),
+        getPackage(S, project5Dir).import()
+      ]);
+      var packageCounts = getPackages(S).groupByKey("name").count();
+      Object.keys(packageCounts).forEach(name =>
+        expect(packageCounts[name]).equals(1, `package ${name} loaded mutiple times`));
     });
 
   });

--- a/tests/package-loading-test.js
+++ b/tests/package-loading-test.js
@@ -33,10 +33,9 @@ var project1aDir = testDir + "dep1/",
       "dep1": project1a,
       "dep2": project1b,
       "project2": project2
-    }
+    };
 
 describe("package loading", function() {
-
 
   var System;
 
@@ -49,6 +48,7 @@ describe("package loading", function() {
   afterEach(() => {
     removeSystem("test")
     // show(printSystemConfig(System)) &&
+    console.log("CLEAN")
     return removeDir(testDir);;
   });
 
@@ -109,6 +109,7 @@ describe("package loading", function() {
     });
 
     it("uses specified dependency when preferLoaded is false", async () => {
+console.log("TEST")
       await modifyJSON(project2Dir + "package.json", {lively: {preferLoadedPackages: false}});
       await registerPackage(System, project2Dir);
       var m = await System.import("project2");
@@ -134,20 +135,13 @@ describe("package loading", function() {
     });
 
     it("Concurrent loading will not load multiple versions", async () => {
-      var project3Dir = testDir + "project3/",
-          project3 = {
+console.log("TEST")
+      var project2bDir = testDir + "project2b/",
+          project2b = {
             "index.js": "export { x, version } from 'some-project';",
             "package.json": JSON.stringify({
               name: "project2", dependencies: {"some-project": "*"},
               lively: {packageMap: {"some-project": project1aDir}}
-            })
-          },
-          project4Dir = testDir + "project4/",
-          project4 = {
-            "index.js": "export { version } from 'some-project';",
-            "package.json": JSON.stringify({
-              name: "project2", dependencies: {"some-project": "*"},
-              lively: {packageMap: {"some-project": project1cDir}}
             })
           },
           project5Dir = testDir + "project5/",
@@ -155,19 +149,15 @@ describe("package loading", function() {
             "index.js": "export { version } from 'project2';",
             "package.json": JSON.stringify({
               name: "project5", dependencies: {"project2": "*"},
-              lively: {packageMap: {"project2": project4Dir}}
+              lively: {packageMap: {"project2": project2bDir}}
             })
-          },
-          project1cDir = testDir + "project1c/",
-          project1c = {"entry-c.js": "var version = 'c';\n", "package.json": '{"name": "some-project", "main": "entry-c.js"}'}
-      await createFiles(project1cDir, project1c);
-      await createFiles(project3Dir, project3);
-      await createFiles(project4Dir, project4);
+          };
+      await createFiles(project2bDir, project2b);
       await createFiles(project5Dir, project5);
       await Promise.all([
         importPackage(System, project2Dir),
-        importPackage(System, project3Dir),
-        importPackage(System, project5Dir)]);
+        importPackage(System, project5Dir)
+        ]);
       console.log(getPackages(System).map(ea => ea.address).join("\n"))
     });
 


### PR DESCRIPTION
The changes here allow us to concurrently load packages and ensure that packages whose dependency are already in the system are using those (`preferLoadedPackages` is enabled by default) without loading their own copy.
