### PR TITLE
Updating bindings in virtual modules

### DIFF
--- a/src/import-export.js
+++ b/src/import-export.js
@@ -61,8 +61,6 @@ function updateModuleExports(System, moduleId, keysAndValues) {
       }
     }
 
-    // For exising exports we find the execution func of each dependent module and run that
-    // FIXME this means we run the entire modules again, side effects and all!!!
     if (existingExports.length) {
       debug && console.log("[lively.vm es6 updateModuleExports] updating %s dependents of %s", record.importers.length, moduleId);
       for (var i = 0, l = record.importers.length; i < l; i++) {
@@ -73,6 +71,8 @@ function updateModuleExports(System, moduleId, keysAndValues) {
           // rk 2016-06-09: for now don't re-execute dependent modules on save,
           // just update module bindings
           if (false) {
+            // For exising exports we find the execution func of each dependent module and run that
+            // FIXME this means we run the entire modules again, side effects and all!!!
             importerModule.execute();
           } else {
             runScheduledExportChanges(System, importerModule.name);

--- a/src/import-export.js
+++ b/src/import-export.js
@@ -60,14 +60,20 @@ function updateModuleExports(System, moduleId, keysAndValues) {
         });
       }
     }
-
     if (existingExports.length) {
       debug && console.log("[lively.vm es6 updateModuleExports] updating %s dependents of %s", record.importers.length, moduleId);
       for (var i = 0, l = record.importers.length; i < l; i++) {
         var importerModule = record.importers[i];
         if (!importerModule.locked) {
-          var importerIndex = importerModule.dependencies.indexOf(record);
-          importerModule.setters[importerIndex](record.exports);
+          // via the module bindings to importer modules we refresh the values
+          // bound in those modules by triggering the setters defined in the
+          // records of those modules
+          var importerIndex,
+              found = importerModule.dependencies.some((dep, i) => { importerIndex = i; return dep && dep.name === record.name})
+          if (found) {
+            importerModule.setters[importerIndex](record.exports);
+          }
+
           // rk 2016-06-09: for now don't re-execute dependent modules on save,
           // just update module bindings
           if (false) {

--- a/tests/eval-test.js
+++ b/tests/eval-test.js
@@ -149,6 +149,10 @@ describe("lively.modules aware eval", () => {
       await runEval("export var z = 23;", {targetModule: m1.id, System: S});
       await runEval(`import { z } from '${m1.id}';`, {targetModule: m2.id, System: S});
       expect(m2).to.have.deep.property("recorder.z", 23);
+      expect(m1.record().importers).to.containSubset([{name: m2.id}]);
+      expect(m2.record().dependencies).to.containSubset([{name: m1.id}]);
+      await runEval("export var z = 24;", {targetModule: m1.id, System: S});
+      expect(m2).to.have.deep.property("recorder.z", 24);
     });
 
   });

--- a/tests/eval-test.js
+++ b/tests/eval-test.js
@@ -141,22 +141,6 @@ describe("lively.modules aware eval", () => {
     expect(m.x).to.equal(4);
   });
 
-  describe("lively modules", () => {
-
-    it("exports and imports", async () => {
-      var m1 = S.get("@lively-env").moduleEnv("lively://foo/mod1"),
-          m2 = S.get("@lively-env").moduleEnv("lively://foo/mod2");
-      await runEval("export var z = 23;", {targetModule: m1.id, System: S});
-      await runEval(`import { z } from '${m1.id}';`, {targetModule: m2.id, System: S});
-      expect(m2).to.have.deep.property("recorder.z", 23);
-      expect(m1.record().importers).to.containSubset([{name: m2.id}]);
-      expect(m2.record().dependencies).to.containSubset([{name: m1.id}]);
-      await runEval("export var z = 24;", {targetModule: m1.id, System: S});
-      expect(m2).to.have.deep.property("recorder.z", 24);
-    });
-
-  });
-
   describe("es6 code", () => {
 
     it("**", () =>

--- a/tests/package-loading-test.js
+++ b/tests/package-loading-test.js
@@ -94,6 +94,26 @@ describe("package loading", function() {
             {deps: [],name: `${project1aDir}package.json`}]
         }])
     })
+
+    it("doesnt group modules with package name as belonging to package", async () => {
+      await getPackage(S, project2Dir).import();
+      // S.set(testDir + "project2.js", S.newModule({}));
+      expect(getPackages(S)).to.containSubset([
+        {
+          address: noTrailingSlash(project2Dir),
+          name: `project2`, referencedAs: [`project2`],
+          modules: [
+            {deps: [`${project1aDir}entry-a.js`], name: `${project2Dir}index.js`},
+            {deps: [], name: `${project2Dir}package.json`}],
+        },
+        {
+          address: noTrailingSlash(project1bDir),
+          name: `some-project`, referencedAs: [`some-project`],
+          modules: [
+            {deps: [`${project1aDir}other.js`], name: `${project1aDir}entry-b.js`},
+            {deps: [],name: `${project1aDir}package.json`}]
+        }])
+    })
   });
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/tests/virtual-modules-test.js
+++ b/tests/virtual-modules-test.js
@@ -1,0 +1,62 @@
+/*global System, beforeEach, afterEach, describe, it*/
+
+import { removeDir, createFiles } from "./helpers.js";
+import { expect } from "mocha-es6";
+import { promise } from "lively.lang";
+
+import { getSystem, removeSystem } from "lively.modules/src/system.js";
+import module from "lively.modules/src/module.js";
+import { runEval } from "lively.vm";
+
+const dir = System.decanonicalize("lively.modules/tests/"),
+      testProjectDir = dir + "files-for-virtual-modules-test/",
+      testProjectSpec = {
+        "file1.js": "export var x = 23;",
+        "package.json": '{"name": "a-project", "main": "file1.js"}'
+      },
+      file1m = testProjectDir + "file1.js";
+
+describe("lively.modules aware eval", () => {
+
+  let S, module1;
+  beforeEach(async () => {
+    S = getSystem("test", {baseURL: testProjectDir});
+    await createFiles(testProjectDir, testProjectSpec);
+    module1 = module(S, file1m);
+  });
+
+  afterEach(async () => {
+    await removeSystem("test");
+    await removeDir(testProjectDir);
+  });
+
+  it("virtual module dependencies stay up-to-date after reloading", async () => {
+    // 1. import real module into virtual module
+    // 2. reload real module
+    // 3. re-import in virtual module
+    // 4. real module source change => should update virtual module, no error
+    await module1.load();
+    var virtualModule = module(S, "lively://foo/mod1");
+    await runEval(`import { x } from '${module1.id}';`, {targetModule: virtualModule.id, System: S});
+    expect(virtualModule).to.have.deep.property("recorder.x", 23);
+    await module1.reload();
+    await runEval(`import { x } from '${module1.id}';`, {targetModule: virtualModule.id, System: S});
+    await module1.changeSource("export var x = 24;");
+    expect(virtualModule).to.have.deep.property("recorder.x", 24);
+  });
+
+
+  it("exports and imports are updated on eval", async () => {
+    var m1 = S.get("@lively-env").moduleEnv("lively://foo/mod1"),
+        m2 = S.get("@lively-env").moduleEnv("lively://foo/mod2");
+    await runEval("export var z = 23;", {targetModule: m1.id, System: S});
+    await runEval(`import { z } from '${m1.id}';`, {targetModule: m2.id, System: S});
+    expect(m2).to.have.deep.property("recorder.z", 23);
+    expect(m1.record().importers).to.containSubset([{name: m2.id}]);
+    expect(m2.record().dependencies).to.containSubset([{name: m1.id}]);
+    await runEval("export var z = 24;", {targetModule: m1.id, System: S});
+    expect(m2).to.have.deep.property("recorder.z", 24);
+  });
+
+});
+


### PR DESCRIPTION
As reported by @levjj 

Right now "virtual" modules that aren't loaded via SystemJS.import don't have the correct dependency info attached to their module records. I.e. that when an exported var in one module changes, the dependent modules aren't correctly updating (normally this happens via binding setters)

![semantics1_480](https://cloud.githubusercontent.com/assets/467450/16471028/03211f1e-3e0f-11e6-9643-cdf73a768b3c.png)
