### PR TITLE
Use System.import to get module source

### DIFF
--- a/dist/lively.modules_no-deps.js
+++ b/dist/lively.modules_no-deps.js
@@ -147,7 +147,9 @@
   function requireMap$1(System) {
     if (System.loads) {
       var store = System.loads,
-          modNames = lively_lang.arr.uniq(Object.keys(loadedModules$1(System)).concat(Object.keys(store)));
+          modNames = lively_lang.arr.uniq(Object.keys(loadedModules$1(System)).concat(Object.keys(store))).filter(function (modName) {
+        return modName.indexOf('!') < 0;
+      });
       return modNames.reduce(function (requireMap, k) {
         var depMap = store[k] ? store[k].depMap : {};
         requireMap[k] = Object.keys(depMap).map(function (localName) {
@@ -190,6 +192,8 @@
   // id => lang.string.include(id, "lively.ast.es6.bundle.js"),
   function (id) {
     return id.slice(-3) !== ".js";
+  }, function (id, load) {
+    return load.metadata.loader;
   }];
   var esmFormatCommentRegExp = /['"]format (esm|es6)['"];/;
   var cjsFormatCommentRegExp = /['"]format cjs['"];/;
@@ -290,7 +294,7 @@
         debug = System.debug;
 
     if (exceptions.some(function (exc) {
-      return exc(load.name);
+      return exc(load.name, load);
     })) {
       debug && console.log("[lively.modules customTranslate ignoring] %s", load.name);
       return proceed(load);
@@ -1761,38 +1765,16 @@
         // all cases b/c modules once loaded by the loaded get cached and System.fetch
         // returns "" in those cases
 
+        // cs 2016-08-01:
+        // We cannot use System.fetch directly but it is possible to use a
+        // text loader plugin to get the original source code. Thereby, any
+        // fetch hooks get respected (e.g. for changesets)
+
         if (this.id === "@empty") return Promise.resolve("");
-
         if (this._source) return Promise.resolve(this._source);
-        if (this.id.match(/^http/) && this.System.global.fetch) {
-          return this.System.global.fetch(this.id).then(function (res) {
-            return res.text();
-          });
-        }
-
-        if (this.id.match(/^file:/) && this.System.get("@system-env").node) {
-          var _ret = function () {
-            var path = _this2.id.replace(/^file:\/\//, "");
-            return {
-              v: new Promise(function (resolve, reject) {
-                return _this2.System._nodeRequire("fs").readFile(path, function (err, content) {
-                  return err ? reject(err) : resolve(_this2._source = String(content));
-                });
-              })
-            };
-          }();
-
-          if ((typeof _ret === "undefined" ? "undefined" : _typeof(_ret)) === "object") return _ret.v;
-        }
-
-        if (this.id.match(/^lively:/) && typeof $world !== "undefined") {
-          // This needs to go into a separate place for "virtual" lively modules
-          var morphId = lively_lang.arr.last(this.id.split("/"));
-          var m = $world.getMorphById(morphId);
-          return Promise.resolve(m ? m.textContent : "");
-        }
-
-        return Promise.reject(new Error("Cannot retrieve source for " + this.id));
+        return this.System.import(this.id + "!lively.modules/src/text-loader.js").then(function (src) {
+          return _this2._source = src;
+        });
       }
     }, {
       key: "ast",
@@ -1936,7 +1918,7 @@
                   m = this.System.get(this.id);
 
                   if (m) {
-                    _context4.next = 5;
+                    _context4.next = 6;
                     break;
                   }
 
@@ -1946,8 +1928,9 @@
                 case 4:
                   m = _context4.sent;
 
-                case 5:
                   lively_notifications.emit("lively.modules/moduleloaded", { module: this.id }, Date.now(), this.System);
+
+                case 6:
                   return _context4.abrupt("return", m);
 
                 case 7:
@@ -3015,7 +2998,8 @@
       System.config({
         map: {
           'plugin-babel': initialSystem.map["plugin-babel"],
-          'systemjs-babel-build': initialSystem.map["systemjs-babel-build"]
+          'systemjs-babel-build': initialSystem.map["systemjs-babel-build"],
+          'lively.modules': initialSystem.decanonicalize("lively.modules/")
         },
         transpiler: initialSystem.transpiler,
         babelOptions: Object.assign(initialSystem.babelOptions || {}, config.babelOptions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lively.modules",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "main": "dist/lively.modules.js",
   "repository": "https://github.com/LivelyKernel/lively.modules",
   "author": "Robert Krahn <robert.krahn@gmail.com>",

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -11,7 +11,8 @@ import { loadedModules } from "./system.js";
 function computeRequireMap(System) {
   if (System.loads) {
     var store = System.loads,
-        modNames = arr.uniq(Object.keys(loadedModules(System)).concat(Object.keys(store)));
+        modNames = arr.uniq(Object.keys(loadedModules(System)).concat(Object.keys(store)))
+          .filter(modName => modName.indexOf('!') < 0);
     return modNames.reduce((requireMap, k) => {
       var depMap = store[k] ? store[k].depMap : {};
       requireMap[k] = Object.keys(depMap).map(localName => {

--- a/src/instrumentation.js
+++ b/src/instrumentation.js
@@ -34,7 +34,8 @@ var exceptions = [
       id => string.include(id, "acorn/src"),
       id => string.include(id, "babel-core/browser.js") || string.include(id, "system.src.js") || string.include(id, "systemjs-plugin-babel"),
       // id => lang.string.include(id, "lively.ast.es6.bundle.js"),
-      id => id.slice(-3) !== ".js"
+      id => id.slice(-3) !== ".js",
+      (id, load) => load.metadata.loader
     ],
     pendingConfigs = [], configInitialized = false,
     esmFormatCommentRegExp = /['"]format (esm|es6)['"];/,
@@ -150,7 +151,7 @@ function customTranslate(proceed, load) {
 
   var System = this, debug = System.debug;
 
-  if (exceptions.some(exc => exc(load.name))) {
+  if (exceptions.some(exc => exc(load.name, load))) {
     debug && console.log("[lively.modules customTranslate ignoring] %s", load.name);
     return proceed(load);
   }

--- a/src/module.js
+++ b/src/module.js
@@ -58,29 +58,15 @@ class ModuleInterface {
     // System.fetch (at least with the current systemjs release) will not work in
     // all cases b/c modules once loaded by the loaded get cached and System.fetch
     // returns "" in those cases
+    
+    // cs 2016-08-01:
+    // We cannot use System.fetch directly but it is possible to use a
+    // text loader plugin to get the original source code. Thereby, any
+    // fetch hooks get respected (e.g. for changesets)
 
     if (this.id === "@empty") return Promise.resolve("")
-
     if (this._source) return Promise.resolve(this._source);
-    if (this.id.match(/^http/) && this.System.global.fetch) {
-      return this.System.global.fetch(this.id).then(res => res.text());
-    }
-
-    if (this.id.match(/^file:/) && this.System.get("@system-env").node) {
-      const path = this.id.replace(/^file:\/\//, "");
-      return new Promise((resolve, reject) =>
-        this.System._nodeRequire("fs").readFile(path, (err, content) =>
-          err ? reject(err) : resolve(this._source = String(content))));
-    }
-
-    if (this.id.match(/^lively:/) && typeof $world !== "undefined") {
-      // This needs to go into a separate place for "virtual" lively modules
-      var morphId = arr.last(this.id.split("/"));
-      var m = $world.getMorphById(morphId);
-      return Promise.resolve(m ? m.textContent : "");
-    }
-
-    return Promise.reject(new Error(`Cannot retrieve source for ${this.id}`));
+    return this.System.import(this.id + "!lively.modules/src/text-loader.js").then(src => this._source = src);
   }
 
   async ast() {

--- a/src/system.js
+++ b/src/system.js
@@ -115,7 +115,8 @@ function prepareSystem(System, config) {
     System.config({
       map: {
         'plugin-babel': initialSystem.map["plugin-babel"],
-        'systemjs-babel-build': initialSystem.map["systemjs-babel-build"]
+        'systemjs-babel-build': initialSystem.map["systemjs-babel-build"],
+        'lively.modules': initialSystem.decanonicalize("lively.modules/")
       },
       transpiler: initialSystem.transpiler,
       babelOptions: Object.assign(initialSystem.babelOptions || {}, config.babelOptions)

--- a/src/text-loader.js
+++ b/src/text-loader.js
@@ -1,0 +1,9 @@
+export function translate(load) {
+  if (this.builder && this.transpiler) {
+    load.metadata.format = 'esm';
+    return 'export default ' + JSON.stringify(load.source) + ';';
+  }
+  
+  load.metadata.format = 'amd';
+  return 'def' + 'ine(function() {\nreturn ' + JSON.stringify(load.source) + ';\n});';
+}

--- a/tests/search-test.js
+++ b/tests/search-test.js
@@ -145,10 +145,10 @@ describe("search", () => {
 
     describe("can exclude modules", () => {
       it("finds comments", async () => {
-        const res = await searchLoadedModules(S, /(im|ex)port/, {excludedModules: [file1m]});
+        const res = await searchLoadedModules(S, /y =/, {excludedModules: [file1m]});
         expect(res).to.have.length(1);
         expect(res).to.containSubset([
-          {module: {id: file2m}, line: 1, column: 0, length: 6}]);
+          {module: {id: file2m}, line: 1, column: 11, length: 3}]);
       });
     });
   });


### PR DESCRIPTION
The `Module` class is able to get the source code of a module for the purposes of parsing, code analysis etc.

However, this is currently not connected to either `lively.resources` or `System.fetch`. Since [ChangeSets](LivelyKernel/lively.changesets) add a hook to `System.fetch`, it would be necessary to also instrument the source code loading of the `Module` class.

This PR uses a text-loader plugin and plugin-syntax to load the original source code of a module from within the Module class based on the current `System`. (A better solution would be to base everything of `lively.resources` but this is not possible with the current design.)
