### PR TITLE
Invoke mocha-es6 in a Windows-compatible way.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Robert Krahn <robert.krahn@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "test": "node_modules/mocha-es6/bin/mocha-es6.js tests/*-test.js",
+    "test": "mocha-es6 tests/*-test.js",
     "build": "node tools/build.js"
   },
   "systemjs": {


### PR DESCRIPTION
npm test automatically adds the node_modules/.bin directory to PATH
and npm install automatically creates .cmd stubs for binaries from
projects. Trying to directly execute a file with a shebang does not
work on Windows. The portable way to invoke mocha-es6 is actually
more concise than the original non-portable method.